### PR TITLE
Release version 0.3.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nested_containment_list"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Anders Evensen"]
 edition = "2018"
 description = "A data structure for efficiently storing and querying nested intervals."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [".github/*"]
 all-features = true
 
 [dependencies]
-doc_item = {version = "0.1.1", optional = true}
+doc_item = {version = "0.3.0", optional = true}
 
 [build-dependencies]
 autocfg = "1.0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1352,7 +1352,7 @@ where
 /// for more information.
 ///
 /// [`Into`]: core::convert::Into
-#[cfg_attr(feature = "doc_item", doc_item::since("1.41.0"))]
+#[cfg_attr(feature = "doc_item", doc_item::since(content="1.41.0"))]
 impl<R, T> From<NestedContainmentList<R, T>> for Vec<R>
 where
     R: RangeBounds<T>,


### PR DESCRIPTION
This simply updates the dependency on doc_item to the now-working version `0.3.0` and prepares for a new release. This fixes the documentation issue that was present a while ago in #26, resolving that issue. 